### PR TITLE
Fix maybe_extract_keys logic and move lambda outside of `util.train` to avoid recompiling lax.cond.

### DIFF
--- a/coix/util.py
+++ b/coix/util.py
@@ -71,13 +71,16 @@ def is_observed_site(site):
 
 
 def can_extract_key(args):
-  return args and (
-      jax.dtypes.issubdtype(args[0].dtype, jax.dtypes.prng_key)
-      or (
-          isinstance(args[0], jnp.ndarray)
-          and (args[0].dtype == jnp.uint32)
-          and (jnp.ndim(args[0]) >= 1)
-          and (args[0].shape[-1] == 2)
+  return (
+      args
+      and isinstance(args[0], jnp.ndarray)
+      and (
+          jax.dtypes.issubdtype(args[0].dtype, jax.dtypes.prng_key)
+          or (
+              (args[0].dtype == jnp.uint32)
+              and (jnp.ndim(args[0]) >= 1)
+              and (args[0].shape[-1] == 2)
+          )
       )
   )
 
@@ -133,6 +136,11 @@ class BindModule:
     return self.module.apply(self.params, *args, **kwargs)
 
 
+def _skip_update(grad, opt_state, params):
+  del params
+  return jax.tree_util.tree_map(jnp.zeros_like, grad), opt_state
+
+
 def train(
     loss_fn,
     init_params,
@@ -164,7 +172,7 @@ def train(
     updates, opt_state = jax.lax.cond(
         jnp.isfinite(jax.flatten_util.ravel_pytree(grads)[0]).all(),
         optimizer.update,
-        lambda g, o, p: (jax.tree_util.tree_map(jnp.zeros_like, g), o),
+        _skip_update,
         grads,
         opt_state,
         params,


### PR DESCRIPTION
Fix maybe_extract_keys logic and move lambda outside of `util.train` to avoid recompiling lax.cond.

FUTURE_COPYBARA_INTEGRATE_REVIEW=https://github.com/jax-ml/coix/pull/15 from jax-ml:prng 222781afd64b8f77482a0f4adee181830b291783
