### PR TITLE
Introduce the `chain` argument to propose

### DIFF
--- a/examples/bmnist.py
+++ b/examples/bmnist.py
@@ -285,7 +285,7 @@ def kernel_what(network, inputs, T=10):
 
 
 # %%
-# Finally, we create the dmm inference program, define the loss function,
+# Finally, we create the bmnist inference program, define the loss function,
 # run the training loop, and plot the results.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ doc = [
     "sphinx-gallery",
 ]
 oryx = [
-    "oryx@git+https://github.com/jax-ml/oryx.git#b59ab020780cd53d488bc7dcad3696be9fdca0a5",
+    "oryx@git+https://github.com/jax-ml/oryx.git@b59ab020780cd53d488bc7dcad3696be9fdca0a5",
 ]
 
 [tool.pyink]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ doc = [
     "sphinx-gallery",
 ]
 oryx = [
-    "oryx@git+https://github.com/jax-ml/oryx",
+    "oryx@git+https://github.com/jax-ml/oryx.git#b59ab020780cd53d488bc7dcad3696be9fdca0a5",
 ]
 
 [tool.pyink]


### PR DESCRIPTION
When proposing `q` to `p`, sometimes we want to pass information from q into p. This PR introduces a `chain` argument to optionally use output of q as input of p.